### PR TITLE
feat: migrate to TypeScript with build toolchain

### DIFF
--- a/.claude/commands/commit-push.md
+++ b/.claude/commands/commit-push.md
@@ -1,0 +1,34 @@
+---
+description: Commit all changes and push to remote.
+---
+
+Commit and push workflow:
+
+1. **Stage all changes**:
+   - Run `git add -A` to stage everything
+
+2. **Create a conventional commit**:
+   - Analyze all staged changes
+   - Use HEREDOC format for the commit message:
+   ```
+   git commit -m "$(cat <<'EOF'
+   <type>(<scope>): <description>
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+3. **Push**:
+   - Run `git push` to push changes
+   - If no upstream is set, use `git push -u origin <branch-name>`
+
+4. **Create or update PR**:
+   - After pushing, check if a PR already exists for the current branch: `gh pr view --json url 2>/dev/null`
+   - If no PR exists, create one with `gh pr create`
+   - If PR exists, update the description with `gh pr edit <number> --body` to reflect all changes made
+   - Use a descriptive title and summary of changes in the body
+
+5. **Output the PR URL** so the user can review it.
+
+Execute the commit and push now.

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,59 @@
+---
+description: Create a feature branch, commit changes, push, and open a PR.
+---
+
+Create PR workflow:
+
+1. **Check current branch state**:
+   - Run `git branch --show-current` to get the current branch
+   - Run `git status` to see uncommitted changes
+   - Run `git log origin/main..HEAD --oneline` to see unpushed commits
+
+2. **Create feature branch if on main**:
+   - If on `main` or `master`:
+     - Generate branch name with format: `<type>/<short-description>`
+     - Example: `feat/add-dark-mode`, `fix/login-validation`
+     - Types: feat, fix, refactor, chore, docs, test, perf
+     - Run `git checkout -b <branch-name>`
+   - If already on a feature branch, continue with that branch
+
+3. **Stage and commit changes**:
+   - Run `git add -A` to stage all changes
+   - Create a conventional commit message based on the changes
+   - Use HEREDOC format:
+   ```
+   git commit -m "$(cat <<'EOF'
+   <type>(<scope>): <description>
+
+   <optional body explaining what and why>
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+4. **Push to remote**:
+   - Use `git push -u origin <branch-name>` to push and set upstream
+
+5. **Create or update PR**:
+   - Check if PR exists: `gh pr view --json url 2>/dev/null`
+   - If no PR exists, create one:
+   ```bash
+   gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+   ## Summary
+   <bullet points describing the changes>
+
+   ## Test plan
+   - [ ] `npm run build` passes
+   - [ ] `npm test` passes (all 33+ tests)
+
+   ---
+   Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+   - If PR exists, update the description with `gh pr edit --body` to reflect current changes
+
+6. **Output the PR URL** so the user can review it.
+
+Execute this workflow now.

--- a/.claude/commands/fix-review.md
+++ b/.claude/commands/fix-review.md
@@ -1,0 +1,57 @@
+---
+description: Fetch PR review comments and fix them all in one pass.
+---
+
+Fix all pending review comments on PR #$ARGUMENTS.
+
+## Steps
+
+1. **Fetch PR review comments**:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments --jq '.[] | select(.in_reply_to_id == null) | {id, path, line, body, diff_hunk}'
+   ```
+   Also fetch top-level PR comments:
+   ```bash
+   gh pr view $ARGUMENTS --comments --json comments
+   ```
+
+2. **Ensure you are on the correct branch** for this PR:
+   ```bash
+   gh pr view $ARGUMENTS --json headRefName --jq '.headRefName'
+   ```
+   Check out the branch if not already on it.
+
+3. **Parse each review comment** to extract:
+   - The file path and line number it's attached to
+   - The comment body (the feedback / requested change)
+
+4. **Create a todo plan** with one todo item per review comment, including the file, line reference, and what was asked for.
+
+5. **Fix ALL review comments**, one by one, following the todo plan:
+   - Apply the minimal change that addresses each comment — do NOT over-engineer
+   - Do NOT modify files that weren't mentioned in review comments unless lint/test fixes require it
+
+6. **Reply to each review comment** on the PR:
+   - Always prefix replies with `Claude's answer:` so they're distinguishable
+   - For each comment you fixed: reply with a concise summary of what you changed
+   - For questions from the reviewer: reply with a direct answer
+   - Reply in-thread:
+     ```bash
+     gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments -f body="Claude's answer: <reply>" -f in_reply_to=COMMENT_ID
+     ```
+
+7. **After all fixes are applied:**
+   - Run `npm run build` and fix any compilation errors
+   - Run `npm test` and fix any test failures
+   - Stage all changed files and use `/commit-push`
+
+8. **After push, summarize on the PR:**
+   ```bash
+   gh pr comment $ARGUMENTS --body "Review feedback addressed: [summary of all changes made, one bullet per comment addressed]"
+   ```
+
+## Constraints
+
+- Do NOT modify files that weren't mentioned in review comments unless build/test requires it
+- Do NOT over-engineer fixes — apply the minimal change that addresses each comment
+- If a comment is ambiguous, make the most reasonable interpretation and note it in the PR summary comment

--- a/.claude/commands/review-claude-settings.md
+++ b/.claude/commands/review-claude-settings.md
@@ -1,0 +1,103 @@
+---
+description: Review .claude/settings.local.json for security issues, garbage entries, and overly specific permissions.
+---
+
+Review `.claude/settings.local.json` for security, hygiene, and completeness.
+
+**Mode:** If `$ARGUMENTS` contains `--full`, analyze the entire file. Otherwise, analyze only the git diff (staged + unstaged changes).
+
+## Steps
+
+1. **Gather the input to review:**
+
+   **Default (diff only):**
+   ```bash
+   git diff HEAD -- .claude/settings.local.json
+   git diff --cached -- .claude/settings.local.json
+   ```
+   If no diff exists, inform the user there are no changes and suggest using `--full`.
+
+   **Full mode (`--full`):**
+   Read the entire `.claude/settings.local.json` file.
+
+2. **Read the full file for context** (even in diff mode, read it to understand what's already covered).
+
+3. **Run the following analyses and produce a structured report:**
+
+   ### a. Garbage Detection
+   Look for entries that are clearly malformed or accidental — typically caused by permission fatigue (clicking "Allow" on a prompt that contained a long command or heredoc content). Signs of garbage:
+   - Entries containing `\n`, `\\n`, heredoc markers (`EOF`, `HEREDOC`), or escaped quotes `\\\"`
+   - Entries containing full file contents or multi-line command bodies
+   - Entries that look like partial commit messages or PR bodies
+   - Entries duplicating broader patterns that already exist
+
+   For each garbage entry found:
+   - Quote the entry
+   - Explain why it's garbage
+   - Recommend: **remove** (harmless noise) or **deny** (if the pattern could allow something dangerous)
+
+   ### b. Security Audit
+   Check allow entries for dangerous patterns:
+   - `Bash(rm:*)` — allows arbitrary `rm` commands (should be scoped or in `ask`)
+   - `Bash(mv:*)` — allows arbitrary moves
+   - `Bash(sed:*)`, `Bash(bash:*)` — allows arbitrary code execution
+   - `Bash(eval:*)`, `Bash(sudo:*)` — should always be denied
+   - `Bash(curl:*)` without restrictions — data exfiltration risk
+   - `Bash(git checkout:*)` broad patterns that could discard work
+   - `Bash(git push:*)` without force-push being denied
+   - Any allow entry that contradicts or undermines a deny entry
+
+   Flag each as: **critical** (move to deny), **warning** (move to ask), or **info** (acceptable with caveat).
+
+   ### c. Overly Specific Entries
+   Find entries that are unnecessarily specific when a broader pattern already exists or would be better:
+   - Specific file paths when a glob would work
+   - Specific subcommands when the parent is already allowed
+   - Duplicate entries (exact or effectively equivalent)
+
+   For each: recommend **remove** (already covered) or **broaden** (replace with pattern).
+
+   ### d. Missing Deny Rules
+   Based on the entries and patterns, **proactively suggest** deny/ask rules the user hasn't thought of. Think adversarially — what could go wrong with these permissions?
+
+   For each suggestion: explain the attack vector and recommend **deny** or **ask**.
+
+   ### e. Duplicate Ask Entries
+   Find exact duplicates in the `ask` list (these accumulate from repeated prompts).
+
+4. **Output format:**
+
+   Present findings grouped by severity, with a summary count at the top:
+
+   ```
+   ## Settings Review Summary
+   - X critical issues
+   - X warnings
+   - X garbage entries to clean
+   - X redundant entries to remove
+   - X new rules suggested
+
+   ### Critical (move to deny)
+   ...
+
+   ### Warnings (move to ask)
+   ...
+
+   ### Garbage (remove or deny)
+   ...
+
+   ### Redundant (remove)
+   ...
+
+   ### Suggested New Rules
+   ...
+   ```
+
+5. **After the report, ask** if the user wants you to apply the recommended fixes automatically.
+
+## Constraints
+
+- Do NOT modify the file unless the user explicitly approves
+- Be paranoid — when in doubt, flag it
+- Always explain the "why" for each finding
+- Group related issues together

--- a/.claude/commands/sync-main.md
+++ b/.claude/commands/sync-main.md
@@ -1,0 +1,28 @@
+---
+description: Sync the current feature branch with main and push.
+---
+
+Sync the current feature branch with main and push:
+
+1. **Fetch and merge main**:
+   - Run `git fetch origin main`
+   - Run `git merge origin/main --no-edit`
+
+2. **Handle conflicts if any**:
+   - If the merge has conflicts, list them clearly and resolve each one
+   - Prefer keeping both sides for additive changes (new rules, new imports, etc.)
+   - For true conflicts, prefer the feature branch changes when intent is clear, otherwise ask
+   - After resolving, verify no conflict markers remain with grep
+   - Stage resolved files and complete the merge commit with `git commit --no-edit`
+
+3. **Verify**:
+   - Run `git status` to confirm clean working tree
+   - Run `git log --oneline -3` to confirm merge commit
+   - Run `npm test` to verify everything still works
+
+4. **Push**:
+   - Run `git push` to push the merge
+
+5. **Report**:
+   - Confirm the branch is up to date with main
+   - Report any files that had conflicts and how they were resolved

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,6 @@
       "Bash(npm test:*)",
       "Bash(npm run build:*)",
       "Bash(npx tsc:*)",
-      "Bash(npm install:*)",
-      "Bash(git checkout:*)",
       "Bash(git add:*)",
       "Bash(git status)",
       "Bash(git diff:*)",
@@ -18,6 +16,10 @@
       "Bash(gh issue create:*)",
       "Bash(gh release create:*)",
       "WebSearch"
+    ],
+    "ask": [
+      "Bash(npm install:*)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test:*)",
+      "Bash(npm run build:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npm install:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue create:*)",
+      "Bash(gh release create:*)",
+      "WebSearch"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.claude/settings.local.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
 sh .husky/scripts/no-commits-on-main.sh
 
-# Type check entire project (catches errors in non-staged files that depend on staged changes)
-npx tsc --noEmit
-
 npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+sh .husky/scripts/no-commits-on-main.sh
+
+# Type check entire project (catches errors in non-staged files that depend on staged changes)
+npx tsc --noEmit
+
+npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+sh .husky/scripts/no-direct-push-main.sh
+
+npm test

--- a/.husky/scripts/no-commits-on-main.sh
+++ b/.husky/scripts/no-commits-on-main.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+branch=$(git branch --show-current)
+
+if [ "$branch" = "main" ]; then
+  printf "\033[0;35mError: Direct commits to the %s branch are not allowed.\033[0m\n" "$branch"
+  exit 1
+fi

--- a/.husky/scripts/no-direct-push-main.sh
+++ b/.husky/scripts/no-direct-push-main.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+branch=$(git branch --show-current)
+
+if [ "$branch" = "main" ]; then
+  printf "\033[0;35mDirect push to %s is not allowed.\033[0m\n" "$branch"
+  exit 1
+fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Claude Code plugin that lets you write permission rules using regex instead of wildcards.
 
-Requires **Node.js >= 14**.
+Requires **Node.js >= 18**.
 
 ## Installation
 
@@ -172,7 +172,7 @@ You can also test rules directly without Claude Code:
 
 ```bash
 echo '{"tool_name":"Bash","tool_input":{"command":"git push --force"},"cwd":"."}' \
-  | node scripts/check-permissions.js
+  | node dist/check-permissions.js
 ```
 
 ## Regex Tips

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check-permissions.js",
+            "command": "${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js",
             "timeout": 5
           }
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "regex-permissions",
+  "version": "0.9.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "regex-permissions",
+      "version": "0.9.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "husky": "^9.1.7",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && node dist/test.js",
-    "prepare": "husky"
+    "prepare": "tsc && husky"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,16 @@
   "description": "Regex-based permission rules for Claude Code",
   "author": "amehmeto",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "scripts": {
-    "test": "node test.js"
+    "build": "tsc",
+    "test": "tsc && node dist/test.js",
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "husky": "^9.1.7",
+    "typescript": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,17 @@
 {
   "name": "regex-permissions",
   "version": "0.9.0",
+  "private": true,
   "description": "Regex-based permission rules for Claude Code",
   "author": "amehmeto",
+  "main": "dist/check-permissions.js",
+  "files": [
+    "dist/",
+    "hooks/",
+    ".claude-plugin/",
+    "regex-permissions.example.json",
+    "README.md"
+  ],
   "engines": {
     "node": ">=18"
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && node dist/test.js",
-    "prepare": "husky",
-    "postinstall": "tsc"
+    "prepare": "tsc && husky"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -5,20 +5,14 @@
   "description": "Regex-based permission rules for Claude Code",
   "author": "amehmeto",
   "main": "dist/check-permissions.js",
-  "files": [
-    "dist/",
-    "hooks/",
-    ".claude-plugin/",
-    "regex-permissions.example.json",
-    "README.md"
-  ],
   "engines": {
     "node": ">=18"
   },
   "scripts": {
     "build": "tsc",
     "test": "tsc && node dist/test.js",
-    "prepare": "tsc && husky"
+    "prepare": "husky",
+    "postinstall": "tsc"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-"use strict";
 
 import fs from "fs";
 import path from "path";
@@ -246,7 +245,7 @@ async function main(): Promise<void> {
   let input: HookInput;
   try {
     const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+    for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
     input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
   } catch {
     return;

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -3,6 +3,7 @@
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { HookInput, HookOutput } from "./types";
 
 // --- Types ---
 
@@ -28,20 +29,6 @@ interface PreparedRules {
   deny: ParsedRule[];
   ask: ParsedRule[];
   allow: ParsedRule[];
-}
-
-interface HookInput {
-  tool_name: string;
-  tool_input: Record<string, string>;
-  cwd?: string;
-}
-
-interface HookOutput {
-  hookSpecificOutput: {
-    hookEventName: string;
-    permissionDecision: string;
-    permissionDecisionReason?: string;
-  };
 }
 
 interface EvalResult {
@@ -295,7 +282,7 @@ async function main(): Promise<void> {
       permissionDecision: result.decision,
     },
   };
-  if (result.reason) output.hookSpecificOutput.permissionDecisionReason = result.reason;
+  if (result.reason) output.hookSpecificOutput!.permissionDecisionReason = result.reason;
   process.stdout.write(JSON.stringify(output) + "\n");
 }
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-"use strict";
 
 import { execFileSync } from "child_process";
 import fs from "fs";

--- a/src/test.ts
+++ b/src/test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { HookOutput } from "./types";
 
 interface ToolInput {
   command?: string;
@@ -17,14 +18,6 @@ interface TestInput {
   tool_name: string;
   tool_input: ToolInput;
   cwd?: string;
-}
-
-interface HookSpecificOutput {
-  permissionDecision?: string;
-}
-
-interface HookOutput {
-  hookSpecificOutput?: HookSpecificOutput;
 }
 
 const SCRIPT = path.join(__dirname, "check-permissions.js");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+export interface HookSpecificOutput {
+  hookEventName?: string;
+  permissionDecision?: string;
+  permissionDecisionReason?: string;
+}
+
+export interface HookOutput {
+  hookSpecificOutput?: HookSpecificOutput;
+}
+
+export interface HookInput {
+  tool_name: string;
+  tool_input: Record<string, string>;
+  cwd?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- Migrate `check-permissions.js` and `test.js` from JavaScript to TypeScript under `src/`
- Add `tsconfig.json` (ES2020/commonjs, output to `dist/`) and build toolchain (`tsc`, husky)
- Add husky pre-commit/pre-push hooks enforcing branch protection and running tests
- Add `.claude/commands` (commit-push, create-pr, fix-review, sync-main, review-claude-settings) and shared `settings.json`
- Update `hooks/hooks.json` to reference `dist/check-permissions.js`
- Bump Node engine requirement to `>=18`
- Build on install via `prepare` script so plugin works immediately after `npm install`

## Review fixes applied
- Remove redundant `"use strict"` from TypeScript source files
- Replace unsafe `chunk as Buffer` cast with `Buffer.from(chunk)`
- Remove duplicate `tsc --noEmit` from pre-commit hook (npm test already runs tsc)
- Add `tsc` to `prepare` script so plugin builds on install
- Move `git checkout` and `npm install` from allow to ask in shared settings

## Test plan
- [x] All 33 existing tests pass after migration (`npm test`)
- [x] TypeScript compiles without errors
- [x] Pre-commit and pre-push hooks execute successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)