### PR TITLE
fix: resolve hook error by ensuring script is executable

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,5 +21,8 @@
       "Bash(npm install:*)",
       "Bash(git checkout:*)"
     ]
+  },
+  "enabledPlugins": {
+    "regex-permissions@local-plugins": true
   }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js\"",
             "timeout": 5
           }
         ]

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc && chmod +x dist/check-permissions.js",
+    "build": "tsc",
     "test": "tsc && node dist/test.js",
-    "prepare": "tsc && chmod +x dist/check-permissions.js && husky"
+    "prepare": "tsc && husky"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/check-permissions.js",
     "test": "tsc && node dist/test.js",
-    "prepare": "tsc && husky"
+    "prepare": "tsc && chmod +x dist/check-permissions.js && husky"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary

- Fix "hook error" by invoking the hook script via `node` instead of relying on direct execution, resolving permission/shebang issues across platforms
- Update `build` and `prepare` scripts to `chmod +x` the output JS file as a safety net
- Enable the local plugin in `.claude/settings.json`

## Changes

- **hooks/hooks.json**: Changed command from `${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js` to `node "${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js"`
- **package.json**: Added `chmod +x dist/check-permissions.js` to `build` and `prepare` scripts
- **.claude/settings.json**: Enabled `regex-permissions@local-plugins` plugin

## Test plan

- [ ] Verify hook executes without "hook error" on macOS
- [ ] Verify hook executes without "hook error" on Linux
- [ ] Confirm permission rules are still enforced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)