### PR TITLE
feat: add requireReason option and fix README discrepancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The `flags` field applies to the content regex only (tool names are always case-
 
 ## Tool Matching
 
-The tool name portion is an **exact match** — `Bash` matches only `Bash`, not `BashExecutor` or `MyBash`. Use alternation for multiple tools:
+The tool name portion is an **anchored regex** — it must match the full tool name (`^(?:...)$`). `Bash` matches only `Bash`, not `BashExecutor` or `MyBash`. Use alternation for multiple tools:
 
 ```json
 "Edit|Write|Read(\\.(ts|js|py)$)"
@@ -82,7 +82,29 @@ The content pattern matches against the tool's primary field:
 | WebFetch   | `url`            |
 | Grep/Glob  | `pattern`        |
 | WebSearch  | `query`          |
-| Other tools  | First of: `command`, `file_path`, `url`, `pattern` |
+| Other tools  | First of: `command`, `file_path`, `url`, `pattern`, `query` |
+
+## Requiring Reasons
+
+Enable `requireReason` to enforce that every rule includes a `reason` field. Rules without one (including all string-form rules) are silently skipped, falling through to native permissions.
+
+```json
+{
+  "regexPermissions": {
+    "requireReason": true,
+    "deny": [
+      { "rule": "Bash(^sudo)", "reason": "No sudo" }
+    ],
+    "allow": [
+      { "rule": "Bash(^git\\s+status)", "reason": "Read-only git" }
+    ]
+  }
+}
+```
+
+This is opt-in — when `requireReason` is not set or `false`, string rules and object rules without `reason` work normally. Skipped rules are visible with `REGEX_PERMISSIONS_DEBUG=1`.
+
+If any of the four config files sets `requireReason: true`, it applies to all merged rules.
 
 ## Evaluation Order
 
@@ -93,7 +115,7 @@ The content pattern matches against the tool's primary field:
 
 Deny always wins. A deny rule cannot be overridden by an ask or allow rule.
 
-For multiline commands, deny and ask rules check each line individually — `^sudo` will catch `sudo` embedded on any line. Allow rules match against the full command string only.
+For multiline commands, deny and ask rules check each line individually — `^sudo` will catch `sudo` embedded on any line. Each line is trimmed and empty lines are skipped, so `^sudo` also catches indented lines like `  sudo`. Allow rules match against the full command string only.
 
 ## Examples
 

--- a/dist/check-permissions.js
+++ b/dist/check-permissions.js
@@ -46,7 +46,7 @@ function getPrimaryContent(toolName, toolInput) {
         return str(toolInput.pattern);
     if (toolName === "WebSearch")
         return str(toolInput.query);
-    return str(toolInput.command) || str(toolInput.file_path) || str(toolInput.url) || str(toolInput.pattern);
+    return str(toolInput.command) || str(toolInput.file_path) || str(toolInput.url) || str(toolInput.pattern) || str(toolInput.query);
 }
 // --- Rule parsing ---
 function parseRule(entry) {
@@ -83,20 +83,31 @@ function mergeConfigs(a, b) {
     if (!b)
         return a;
     return {
+        requireReason: a.requireReason || b.requireReason,
         deny: (a.deny || []).concat(b.deny || []),
         ask: (a.ask || []).concat(b.ask || []),
         allow: (a.allow || []).concat(b.allow || []),
     };
 }
 function prepareRules(config) {
+    const requireReason = config.requireReason === true;
     const toArray = (key) => {
         const val = config[key];
         return Array.isArray(val) ? val : [];
     };
+    const parse = (entries) => entries.map(parseRule).filter((r) => {
+        if (r === null)
+            return false;
+        if (requireReason && !r.reason) {
+            debug(`Skipping rule without reason (requireReason is enabled): ${r.toolRe.source} / ${r.contentRe.source}`);
+            return false;
+        }
+        return true;
+    });
     return {
-        deny: toArray("deny").map(parseRule).filter((r) => r !== null),
-        ask: toArray("ask").map(parseRule).filter((r) => r !== null),
-        allow: toArray("allow").map(parseRule).filter((r) => r !== null),
+        deny: parse(toArray("deny")),
+        ask: parse(toArray("ask")),
+        allow: parse(toArray("allow")),
     };
 }
 // --- Evaluation ---

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -18,6 +18,7 @@ interface ParsedRule {
 }
 
 interface RegexPermissionsConfig {
+  requireReason?: boolean;
   deny?: (string | RuleEntry)[];
   ask?: (string | RuleEntry)[];
   allow?: (string | RuleEntry)[];
@@ -71,7 +72,7 @@ function getPrimaryContent(
   if (toolName === "WebFetch") return str(toolInput.url);
   if (toolName === "Grep" || toolName === "Glob") return str(toolInput.pattern);
   if (toolName === "WebSearch") return str(toolInput.query);
-  return str(toolInput.command) || str(toolInput.file_path) || str(toolInput.url) || str(toolInput.pattern);
+  return str(toolInput.command) || str(toolInput.file_path) || str(toolInput.url) || str(toolInput.pattern) || str(toolInput.query);
 }
 
 // --- Rule parsing ---
@@ -114,6 +115,7 @@ function mergeConfigs(
   if (!a) return b || {};
   if (!b) return a;
   return {
+    requireReason: a.requireReason || b.requireReason,
     deny: (a.deny || []).concat(b.deny || []),
     ask: (a.ask || []).concat(b.ask || []),
     allow: (a.allow || []).concat(b.allow || []),
@@ -121,14 +123,24 @@ function mergeConfigs(
 }
 
 function prepareRules(config: RegexPermissionsConfig): PreparedRules {
-  const toArray = (key: keyof RegexPermissionsConfig) => {
+  const requireReason = config.requireReason === true;
+  const toArray = (key: "deny" | "ask" | "allow") => {
     const val = config[key];
     return Array.isArray(val) ? val : [];
   };
+  const parse = (entries: (string | RuleEntry)[]) =>
+    entries.map(parseRule).filter((r): r is ParsedRule => {
+      if (r === null) return false;
+      if (requireReason && !r.reason) {
+        debug(`Skipping rule without reason (requireReason is enabled): ${r.toolRe.source} / ${r.contentRe.source}`);
+        return false;
+      }
+      return true;
+    });
   return {
-    deny: toArray("deny").map(parseRule).filter((r): r is ParsedRule => r !== null),
-    ask: toArray("ask").map(parseRule).filter((r): r is ParsedRule => r !== null),
-    allow: toArray("allow").map(parseRule).filter((r): r is ParsedRule => r !== null),
+    deny: parse(toArray("deny")),
+    ask: parse(toArray("ask")),
+    allow: parse(toArray("allow")),
   };
 }
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -159,6 +159,11 @@ test("passthrough: unknown tool with command field",
   { tool_name: "CustomTool", tool_input: { command: "git status" } },
   "passthrough", TMP);
 
+// --- Multiline trimming ---
+test("deny: multiline with indented sudo (trimmed)",
+  { tool_name: "Bash", tool_input: { command: "echo hello\n  sudo rm -rf /" } },
+  "deny", TMP);
+
 fs.rmSync(TMP, { recursive: true, force: true });
 
 // --- Empty config → passthrough ---
@@ -199,6 +204,20 @@ fs.rmSync(TMP, { recursive: true, force: true });
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
+// --- Unknown tool with query fallback ---
+{
+  const tmp = makeTmpWithConfig({
+    regexPermissions: { allow: ["CustomSearch(node docs)"] },
+  });
+  test("allow: unknown tool falls back to query field",
+    { tool_name: "CustomSearch", tool_input: { query: "node docs" } },
+    "allow", tmp);
+  test("passthrough: unknown tool with no matching fallback field",
+    { tool_name: "CustomSearch", tool_input: { other: "node docs" } },
+    "passthrough", tmp);
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
 // --- Native rules in permissions key are ignored ---
 {
   const tmp = makeTmpWithConfig({
@@ -210,6 +229,49 @@ fs.rmSync(TMP, { recursive: true, force: true });
     "passthrough", tmp);
   test("allow: regexPermissions key is used",
     { tool_name: "Bash", tool_input: { command: "git status" } },
+    "allow", tmp);
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- requireReason: rules without reason are skipped ---
+{
+  const tmp = makeTmpWithConfig({
+    regexPermissions: {
+      requireReason: true,
+      deny: [
+        { rule: "Bash(^sudo)", reason: "No sudo" },
+        "Bash(^rm)",
+      ],
+      allow: [
+        "Bash(^git\\s+status)",
+        { rule: "Bash(^echo)", reason: "Allow echo" },
+      ],
+    },
+  });
+  test("deny: rule with reason is kept when requireReason is enabled",
+    { tool_name: "Bash", tool_input: { command: "sudo rm -rf /" } },
+    "deny", tmp);
+  test("passthrough: deny string rule (no reason) is skipped when requireReason is enabled",
+    { tool_name: "Bash", tool_input: { command: "rm file.txt" } },
+    "passthrough", tmp);
+  test("passthrough: allow string rule (no reason) is skipped when requireReason is enabled",
+    { tool_name: "Bash", tool_input: { command: "git status" } },
+    "passthrough", tmp);
+  test("allow: allow object rule with reason is kept when requireReason is enabled",
+    { tool_name: "Bash", tool_input: { command: "echo hello" } },
+    "allow", tmp);
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- requireReason: false (default) keeps all rules ---
+{
+  const tmp = makeTmpWithConfig({
+    regexPermissions: {
+      allow: ["Bash(^ls)"],
+    },
+  });
+  test("allow: string rule works when requireReason is not set",
+    { tool_name: "Bash", tool_input: { command: "ls -la" } },
     "allow", tmp);
   fs.rmSync(tmp, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

- **`requireReason` option**: Opt-in config flag that enforces every rule includes a `reason` field. Rules without one (including string-form rules) are silently skipped, falling through to native permissions. When any of the four config files sets `requireReason: true`, it applies to all merged rules.
- **Fix tool name docs**: README said "exact match" but the code uses an anchored regex (`^(?:...)$`). Updated to "anchored regex" with explanation.
- **Fix multiline trimming docs**: Lines are trimmed and empties filtered before per-line matching. `^sudo` catches indented `  sudo`. Now documented.
- **Add `query` to "Other tools" fallback**: `getPrimaryContent` now includes `query` in the fallback chain for unknown tools, matching the existing `WebSearch` → `query` special case.

## Test plan

- [x] 39/39 tests pass, including new tests for:
  - `requireReason: true` skips string rules and object rules without reason
  - `requireReason: false` (default) keeps all rules unchanged
  - Multiline with indented `sudo` is caught (trimming)
  - Unknown tool with `query` field matches via fallback
  - Unknown tool with unrecognized field passes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)