### PR TITLE
feat: tool-name-only rules, guard auto mode, config validation, debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ Tool name regex ──┐    ┌── Content regex
 { "rule": "Bash(^git\\s+push)", "reason": "Confirm before pushing", "flags": "i" }
 ```
 
+**Tool-name-only form** — omit parentheses to match any content. Useful for MCP and Skill tools where the plugin cannot inspect input fields:
+```json
+{
+  "deny": [
+    { "rule": "mcp__github__merge_pull_request", "reason": "No merge via MCP" }
+  ],
+  "allow": [
+    "mcp__github__list_pulls",
+    "Glob|Grep|WebSearch"
+  ]
+}
+```
+
 The `flags` field applies to the content regex only (tool names are always case-sensitive).
 
 ## Tool Matching
@@ -110,20 +123,24 @@ If any of the four config files sets `requireReason: true`, it applies to all me
 
 When Claude Code's "don't ask again" prompt is accepted, it writes a native wildcard rule to `settings.local.json`. Enable `guardNativePermissions` to automatically revert these entries and suggest the regex equivalent:
 
+**Suggest mode** — removes the native entry and prints the suggested regex:
 ```json
-{
-  "regexPermissions": {
-    "guardNativePermissions": true
-  }
-}
+{ "guardNativePermissions": true }
 ```
-
-On each hook invocation, the guard removes `permissions.allow` entries for tools that regex-permissions manages (Bash, Edit, Write, Read, WebFetch, Grep, Glob, WebSearch) and prints the suggested regex to stderr:
-
 ```
 [regex-permissions] Removed native allow: Bash(git fetch:*)
   → Add to regexPermissions.allow: { "rule": "Bash(^git\\s+fetch\\b)", "reason": "..." }
 ```
+
+**Auto mode** — removes the native entry AND adds the converted regex to `regexPermissions.allow` automatically:
+```json
+{ "guardNativePermissions": "auto" }
+```
+```
+[regex-permissions] Converted native allow: Bash(git fetch:*) → { "rule": "Bash(^git\\s+fetch\\b)" }
+```
+
+Auto-added rules take effect immediately on the same tool call.
 
 Only `allow` entries with patterns are removed — the guard does not touch `deny` or `ask` entries (which are intentional safety rules, not auto-added). Bare tool names like `"Edit"` and non-managed entries (Skill, MCP, BashOutput) are always kept. The guard only modifies `settings.local.json`, never the committed `settings.json` or global config.
 
@@ -192,21 +209,35 @@ The plugin **fails open** — if anything goes wrong, native permissions take ov
 - Invalid regex → that rule is skipped
 - Unsafe regex (ReDoS) → that rule is skipped
 - Non-array config value → skipped
+- Unknown config key → warning to stderr, rules still work
 - Script crash → 5-second timeout, passthrough
 
 ## Debugging
 
-Set the environment variable to see rule loading and skipped rules:
+Set the environment variable to see which rule matched each decision:
 
 ```bash
 REGEX_PERMISSIONS_DEBUG=1 claude
+```
+
+Example debug output:
+```
+[regex-permissions] Loaded 3 deny, 2 ask, 5 allow rules
+[regex-permissions] DENY Bash "git push --force" → Bash(^git\s+push\s+.*--force) (No force push)
+[regex-permissions] ALLOW Bash "git status" → Bash(^git\s+(status|log|diff))
+[regex-permissions] PASS Bash "some-unknown-cmd" → no match
+```
+
+Debug also warns about unknown config keys (possible typos):
+```
+[regex-permissions] Unknown config key: "requierReason" (did you mean "requireReason"?)
 ```
 
 Test rules directly without Claude Code:
 
 ```bash
 echo '{"tool_name":"Bash","tool_input":{"command":"git push --force"},"cwd":"."}' \
-  | node dist/check-permissions.js
+  | REGEX_PERMISSIONS_DEBUG=1 node dist/check-permissions.js
 ```
 
 ## Regex Tips

--- a/dist/check-permissions.js
+++ b/dist/check-permissions.js
@@ -96,10 +96,13 @@ function readJsonFile(filePath) {
 }
 function loadConfig(filePath) {
     const json = readJsonFile(filePath);
-    return json?.regexPermissions || null;
+    const config = json?.regexPermissions || null;
+    if (config)
+        validateConfig(config, filePath);
+    return config;
 }
 const KNOWN_CONFIG_KEYS = new Set(["requireReason", "guardNativePermissions", "deny", "ask", "allow"]);
-function validateConfig(config) {
+function validateConfig(config, filePath) {
     for (const key of Object.keys(config)) {
         if (!KNOWN_CONFIG_KEYS.has(key)) {
             let suggestion = "";
@@ -109,7 +112,7 @@ function validateConfig(config) {
                     break;
                 }
             }
-            process.stderr.write(`[regex-permissions] Unknown config key: "${key}"${suggestion}\n`);
+            process.stderr.write(`[regex-permissions] Unknown config key "${key}" in ${filePath}${suggestion}\n`);
         }
     }
 }
@@ -299,7 +302,6 @@ async function main() {
     const globalHome = path_1.default.join(os_1.default.homedir(), ".claude");
     const globalConfig = mergeConfigs(loadConfig(path_1.default.join(globalHome, "settings.json")), loadConfig(path_1.default.join(globalHome, "settings.local.json")));
     const merged = mergeConfigs(projectConfig, globalConfig);
-    validateConfig(merged);
     if (merged.guardNativePermissions && cwd) {
         const autoAdd = merged.guardNativePermissions === "auto";
         const added = guardNativePermissions(path_1.default.join(cwd, ".claude", "settings.local.json"), autoAdd);

--- a/dist/check-permissions.js
+++ b/dist/check-permissions.js
@@ -54,8 +54,18 @@ function parseRule(entry) {
     if (!raw)
         return null;
     const match = raw.match(/^([^(]+)\((.+)\)$/s);
-    if (!match)
-        return null;
+    if (!match) {
+        // Tool-name-only rule (no parentheses) — matches any content
+        const toolRe = toRegex(`^(?:${raw})$`);
+        if (!toolRe)
+            return null;
+        return {
+            toolRe,
+            contentRe: null,
+            reason: typeof entry === "object" ? entry.reason : undefined,
+            source: raw,
+        };
+    }
     const flags = typeof entry === "object" ? entry.flags : undefined;
     const toolRe = toRegex(`^(?:${match[1]})$`);
     const contentRe = toRegex(match[2], flags);
@@ -65,16 +75,42 @@ function parseRule(entry) {
         toolRe,
         contentRe,
         reason: typeof entry === "object" ? entry.reason : undefined,
+        source: raw,
     };
 }
 // --- Config loading ---
-function loadConfig(filePath) {
+const jsonCache = new Map();
+function readJsonFile(filePath) {
+    if (jsonCache.has(filePath))
+        return jsonCache.get(filePath);
     try {
         const raw = fs_1.default.readFileSync(filePath, "utf8");
-        return JSON.parse(raw).regexPermissions || null;
+        const json = JSON.parse(raw);
+        jsonCache.set(filePath, json);
+        return json;
     }
     catch {
+        jsonCache.set(filePath, null);
         return null;
+    }
+}
+function loadConfig(filePath) {
+    const json = readJsonFile(filePath);
+    return json?.regexPermissions || null;
+}
+const KNOWN_CONFIG_KEYS = new Set(["requireReason", "guardNativePermissions", "deny", "ask", "allow"]);
+function validateConfig(config) {
+    for (const key of Object.keys(config)) {
+        if (!KNOWN_CONFIG_KEYS.has(key)) {
+            let suggestion = "";
+            for (const known of KNOWN_CONFIG_KEYS) {
+                if (known.toLowerCase().startsWith(key.toLowerCase().slice(0, 4))) {
+                    suggestion = ` (did you mean "${known}"?)`;
+                    break;
+                }
+            }
+            process.stderr.write(`[regex-permissions] Unknown config key: "${key}"${suggestion}\n`);
+        }
     }
 }
 function mergeConfigs(a, b) {
@@ -84,7 +120,9 @@ function mergeConfigs(a, b) {
         return a;
     return {
         requireReason: a.requireReason || b.requireReason,
-        guardNativePermissions: a.guardNativePermissions || b.guardNativePermissions,
+        guardNativePermissions: a.guardNativePermissions === "auto" || b.guardNativePermissions === "auto"
+            ? "auto"
+            : a.guardNativePermissions || b.guardNativePermissions,
         deny: (a.deny || []).concat(b.deny || []),
         ask: (a.ask || []).concat(b.ask || []),
         allow: (a.allow || []).concat(b.allow || []),
@@ -100,7 +138,7 @@ function prepareRules(config) {
         if (r === null)
             return false;
         if (requireReason && !r.reason) {
-            debug(`Skipping rule without reason (requireReason is enabled): ${r.toolRe.source} / ${r.contentRe.source}`);
+            debug(`Skipping rule without reason (requireReason is enabled): ${r.source}`);
             return false;
         }
         return true;
@@ -115,6 +153,8 @@ function prepareRules(config) {
 function ruleMatches(rule, toolName, content) {
     if (!rule.toolRe.test(toolName))
         return false;
+    if (rule.contentRe === null)
+        return true; // tool-name-only: match any content
     if (content == null)
         return false;
     return rule.contentRe.test(content);
@@ -128,21 +168,29 @@ function matchesAnyLine(rule, toolName, content, lines) {
 }
 function evaluate(rules, toolName, toolInput) {
     const content = getPrimaryContent(toolName, toolInput);
+    const contentPreview = content ? JSON.stringify(content.length > 80 ? content.slice(0, 80) + "…" : content) : "(no content)";
     const lines = content?.includes("\n")
         ? content.split("\n").map((l) => l.trim()).filter(Boolean)
         : null;
     for (const rule of rules.deny) {
-        if (matchesAnyLine(rule, toolName, content, lines))
+        if (matchesAnyLine(rule, toolName, content, lines)) {
+            debug(`DENY ${toolName} ${contentPreview} → ${rule.source}${rule.reason ? ` (${rule.reason})` : ""}`);
             return { decision: "deny", reason: rule.reason || "Blocked by regex-permissions deny rule" };
+        }
     }
     for (const rule of rules.ask) {
-        if (matchesAnyLine(rule, toolName, content, lines))
+        if (matchesAnyLine(rule, toolName, content, lines)) {
+            debug(`ASK ${toolName} ${contentPreview} → ${rule.source}${rule.reason ? ` (${rule.reason})` : ""}`);
             return { decision: "ask", reason: rule.reason || "Flagged by regex-permissions ask rule" };
+        }
     }
     for (const rule of rules.allow) {
-        if (ruleMatches(rule, toolName, content))
+        if (ruleMatches(rule, toolName, content)) {
+            debug(`ALLOW ${toolName} ${contentPreview} → ${rule.source}`);
             return { decision: "allow" };
+        }
     }
+    debug(`PASS ${toolName} ${contentPreview} → no match`);
     return null;
 }
 // --- Native permissions guard ---
@@ -169,27 +217,16 @@ function suggestRegex(native) {
     const needsBoundary = isBash && /\w$/.test(core);
     return needsBoundary ? `${tool}(^${core}\\b)` : `${tool}(^${core})`;
 }
-function guardNativePermissions(filePath) {
-    let raw;
-    try {
-        raw = fs_1.default.readFileSync(filePath, "utf8");
-    }
-    catch {
-        return;
-    }
-    let json;
-    try {
-        json = JSON.parse(raw);
-    }
-    catch {
-        return;
-    }
+function guardNativePermissions(filePath, autoAdd) {
+    const json = readJsonFile(filePath);
+    if (!json)
+        return [];
     const perms = json.permissions;
     if (!perms)
-        return;
+        return [];
     const allowEntries = perms.allow;
     if (!Array.isArray(allowEntries))
-        return;
+        return [];
     let changed = false;
     const removed = [];
     const kept = [];
@@ -204,7 +241,7 @@ function guardNativePermissions(filePath) {
         }
     }
     if (!changed)
-        return;
+        return [];
     if (kept.length > 0) {
         perms.allow = kept;
     }
@@ -214,11 +251,32 @@ function guardNativePermissions(filePath) {
     if (Object.keys(perms).length === 0) {
         delete json.permissions;
     }
+    const addedRules = [];
+    if (autoAdd) {
+        if (!json.regexPermissions)
+            json.regexPermissions = {};
+        const rp = json.regexPermissions;
+        if (!rp.allow)
+            rp.allow = [];
+        for (const { suggestion } of removed) {
+            const ruleEntry = { rule: suggestion, reason: "Auto-converted from native permissions" };
+            addedRules.push(ruleEntry);
+            rp.allow.push(ruleEntry);
+        }
+    }
+    // Invalidate cache before writing
+    jsonCache.delete(filePath);
     fs_1.default.writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n");
     for (const { entry, suggestion } of removed) {
-        process.stderr.write(`[regex-permissions] Removed native allow: ${entry}\n` +
-            `  → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }\n`);
+        if (autoAdd) {
+            process.stderr.write(`[regex-permissions] Converted native allow: ${entry} → { "rule": ${JSON.stringify(suggestion)} }\n`);
+        }
+        else {
+            process.stderr.write(`[regex-permissions] Removed native allow: ${entry}\n` +
+                `  → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }\n`);
+        }
     }
+    return addedRules;
 }
 // --- Main ---
 async function main() {
@@ -241,8 +299,13 @@ async function main() {
     const globalHome = path_1.default.join(os_1.default.homedir(), ".claude");
     const globalConfig = mergeConfigs(loadConfig(path_1.default.join(globalHome, "settings.json")), loadConfig(path_1.default.join(globalHome, "settings.local.json")));
     const merged = mergeConfigs(projectConfig, globalConfig);
+    validateConfig(merged);
     if (merged.guardNativePermissions && cwd) {
-        guardNativePermissions(path_1.default.join(cwd, ".claude", "settings.local.json"));
+        const autoAdd = merged.guardNativePermissions === "auto";
+        const added = guardNativePermissions(path_1.default.join(cwd, ".claude", "settings.local.json"), autoAdd);
+        if (added.length > 0) {
+            merged.allow = (merged.allow || []).concat(added);
+        }
     }
     const rules = prepareRules(merged);
     if (!rules.deny.length && !rules.ask.length && !rules.allow.length)

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -13,13 +13,14 @@ interface RuleEntry {
 
 interface ParsedRule {
   toolRe: RegExp;
-  contentRe: RegExp;
+  contentRe: RegExp | null; // null = tool-name-only rule, matches any content
   reason?: string;
+  source: string; // original rule string for debug output
 }
 
 interface RegexPermissionsConfig {
   requireReason?: boolean;
-  guardNativePermissions?: boolean;
+  guardNativePermissions?: boolean | "auto";
   deny?: (string | RuleEntry)[];
   ask?: (string | RuleEntry)[];
   allow?: (string | RuleEntry)[];
@@ -83,7 +84,18 @@ function parseRule(entry: string | RuleEntry): ParsedRule | null {
   if (!raw) return null;
 
   const match = raw.match(/^([^(]+)\((.+)\)$/s);
-  if (!match) return null;
+
+  if (!match) {
+    // Tool-name-only rule (no parentheses) — matches any content
+    const toolRe = toRegex(`^(?:${raw})$`);
+    if (!toolRe) return null;
+    return {
+      toolRe,
+      contentRe: null,
+      reason: typeof entry === "object" ? entry.reason : undefined,
+      source: raw,
+    };
+  }
 
   const flags = typeof entry === "object" ? entry.flags : undefined;
   const toolRe = toRegex(`^(?:${match[1]})$`);
@@ -95,17 +107,46 @@ function parseRule(entry: string | RuleEntry): ParsedRule | null {
     toolRe,
     contentRe,
     reason: typeof entry === "object" ? entry.reason : undefined,
+    source: raw,
   };
 }
 
 // --- Config loading ---
 
-function loadConfig(filePath: string): RegexPermissionsConfig | null {
+const jsonCache = new Map<string, Record<string, unknown> | null>();
+
+function readJsonFile(filePath: string): Record<string, unknown> | null {
+  if (jsonCache.has(filePath)) return jsonCache.get(filePath)!;
   try {
     const raw = fs.readFileSync(filePath, "utf8");
-    return JSON.parse(raw).regexPermissions || null;
+    const json = JSON.parse(raw);
+    jsonCache.set(filePath, json);
+    return json;
   } catch {
+    jsonCache.set(filePath, null);
     return null;
+  }
+}
+
+function loadConfig(filePath: string): RegexPermissionsConfig | null {
+  const json = readJsonFile(filePath);
+  return (json?.regexPermissions as RegexPermissionsConfig) || null;
+}
+
+const KNOWN_CONFIG_KEYS = new Set(["requireReason", "guardNativePermissions", "deny", "ask", "allow"]);
+
+function validateConfig(config: RegexPermissionsConfig): void {
+  for (const key of Object.keys(config)) {
+    if (!KNOWN_CONFIG_KEYS.has(key)) {
+      let suggestion = "";
+      for (const known of KNOWN_CONFIG_KEYS) {
+        if (known.toLowerCase().startsWith(key.toLowerCase().slice(0, 4))) {
+          suggestion = ` (did you mean "${known}"?)`;
+          break;
+        }
+      }
+      process.stderr.write(`[regex-permissions] Unknown config key: "${key}"${suggestion}\n`);
+    }
   }
 }
 
@@ -117,7 +158,10 @@ function mergeConfigs(
   if (!b) return a;
   return {
     requireReason: a.requireReason || b.requireReason,
-    guardNativePermissions: a.guardNativePermissions || b.guardNativePermissions,
+    guardNativePermissions:
+      a.guardNativePermissions === "auto" || b.guardNativePermissions === "auto"
+        ? "auto"
+        : a.guardNativePermissions || b.guardNativePermissions,
     deny: (a.deny || []).concat(b.deny || []),
     ask: (a.ask || []).concat(b.ask || []),
     allow: (a.allow || []).concat(b.allow || []),
@@ -134,7 +178,7 @@ function prepareRules(config: RegexPermissionsConfig): PreparedRules {
     entries.map(parseRule).filter((r): r is ParsedRule => {
       if (r === null) return false;
       if (requireReason && !r.reason) {
-        debug(`Skipping rule without reason (requireReason is enabled): ${r.toolRe.source} / ${r.contentRe.source}`);
+        debug(`Skipping rule without reason (requireReason is enabled): ${r.source}`);
         return false;
       }
       return true;
@@ -154,6 +198,7 @@ function ruleMatches(
   content: string | undefined,
 ): boolean {
   if (!rule.toolRe.test(toolName)) return false;
+  if (rule.contentRe === null) return true; // tool-name-only: match any content
   if (content == null) return false;
   return rule.contentRe.test(content);
 }
@@ -175,25 +220,33 @@ function evaluate(
   toolInput: Record<string, unknown>,
 ): { decision: "deny" | "ask" | "allow"; reason?: string } | null {
   const content = getPrimaryContent(toolName, toolInput);
+  const contentPreview = content ? JSON.stringify(content.length > 80 ? content.slice(0, 80) + "…" : content) : "(no content)";
   const lines = content?.includes("\n")
     ? content.split("\n").map((l) => l.trim()).filter(Boolean)
     : null;
 
   for (const rule of rules.deny) {
-    if (matchesAnyLine(rule, toolName, content, lines))
+    if (matchesAnyLine(rule, toolName, content, lines)) {
+      debug(`DENY ${toolName} ${contentPreview} → ${rule.source}${rule.reason ? ` (${rule.reason})` : ""}`);
       return { decision: "deny", reason: rule.reason || "Blocked by regex-permissions deny rule" };
+    }
   }
 
   for (const rule of rules.ask) {
-    if (matchesAnyLine(rule, toolName, content, lines))
+    if (matchesAnyLine(rule, toolName, content, lines)) {
+      debug(`ASK ${toolName} ${contentPreview} → ${rule.source}${rule.reason ? ` (${rule.reason})` : ""}`);
       return { decision: "ask", reason: rule.reason || "Flagged by regex-permissions ask rule" };
+    }
   }
 
   for (const rule of rules.allow) {
-    if (ruleMatches(rule, toolName, content))
+    if (ruleMatches(rule, toolName, content)) {
+      debug(`ALLOW ${toolName} ${contentPreview} → ${rule.source}`);
       return { decision: "allow" };
+    }
   }
 
+  debug(`PASS ${toolName} ${contentPreview} → no match`);
   return null;
 }
 
@@ -226,26 +279,15 @@ function suggestRegex(native: string): string {
   return needsBoundary ? `${tool}(^${core}\\b)` : `${tool}(^${core})`;
 }
 
-function guardNativePermissions(filePath: string): void {
-  let raw: string;
-  try {
-    raw = fs.readFileSync(filePath, "utf8");
-  } catch {
-    return;
-  }
-
-  let json: Record<string, unknown>;
-  try {
-    json = JSON.parse(raw);
-  } catch {
-    return;
-  }
+function guardNativePermissions(filePath: string, autoAdd: boolean): RuleEntry[] {
+  const json = readJsonFile(filePath);
+  if (!json) return [];
 
   const perms = json.permissions as Record<string, unknown> | undefined;
-  if (!perms) return;
+  if (!perms) return [];
 
   const allowEntries = perms.allow;
-  if (!Array.isArray(allowEntries)) return;
+  if (!Array.isArray(allowEntries)) return [];
 
   let changed = false;
   const removed: Array<{ entry: string; suggestion: string }> = [];
@@ -261,7 +303,7 @@ function guardNativePermissions(filePath: string): void {
     }
   }
 
-  if (!changed) return;
+  if (!changed) return [];
 
   if (kept.length > 0) {
     perms.allow = kept;
@@ -272,14 +314,37 @@ function guardNativePermissions(filePath: string): void {
     delete json.permissions;
   }
 
+  const addedRules: RuleEntry[] = [];
+
+  if (autoAdd) {
+    if (!json.regexPermissions) json.regexPermissions = {};
+    const rp = json.regexPermissions as RegexPermissionsConfig;
+    if (!rp.allow) rp.allow = [];
+    for (const { suggestion } of removed) {
+      const ruleEntry: RuleEntry = { rule: suggestion, reason: "Auto-converted from native permissions" };
+      addedRules.push(ruleEntry);
+      (rp.allow as RuleEntry[]).push(ruleEntry);
+    }
+  }
+
+  // Invalidate cache before writing
+  jsonCache.delete(filePath);
   fs.writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n");
 
   for (const { entry, suggestion } of removed) {
-    process.stderr.write(
-      `[regex-permissions] Removed native allow: ${entry}\n` +
-      `  → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }\n`,
-    );
+    if (autoAdd) {
+      process.stderr.write(
+        `[regex-permissions] Converted native allow: ${entry} → { "rule": ${JSON.stringify(suggestion)} }\n`,
+      );
+    } else {
+      process.stderr.write(
+        `[regex-permissions] Removed native allow: ${entry}\n` +
+        `  → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }\n`,
+      );
+    }
   }
+
+  return addedRules;
 }
 
 // --- Main ---
@@ -312,8 +377,17 @@ async function main(): Promise<void> {
 
   const merged = mergeConfigs(projectConfig, globalConfig);
 
+  validateConfig(merged);
+
   if (merged.guardNativePermissions && cwd) {
-    guardNativePermissions(path.join(cwd, ".claude", "settings.local.json"));
+    const autoAdd = merged.guardNativePermissions === "auto";
+    const added = guardNativePermissions(
+      path.join(cwd, ".claude", "settings.local.json"),
+      autoAdd,
+    );
+    if (added.length > 0) {
+      merged.allow = (merged.allow || []).concat(added);
+    }
   }
 
   const rules = prepareRules(merged);

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -130,12 +130,14 @@ function readJsonFile(filePath: string): Record<string, unknown> | null {
 
 function loadConfig(filePath: string): RegexPermissionsConfig | null {
   const json = readJsonFile(filePath);
-  return (json?.regexPermissions as RegexPermissionsConfig) || null;
+  const config = (json?.regexPermissions as RegexPermissionsConfig) || null;
+  if (config) validateConfig(config, filePath);
+  return config;
 }
 
 const KNOWN_CONFIG_KEYS = new Set(["requireReason", "guardNativePermissions", "deny", "ask", "allow"]);
 
-function validateConfig(config: RegexPermissionsConfig): void {
+function validateConfig(config: RegexPermissionsConfig, filePath: string): void {
   for (const key of Object.keys(config)) {
     if (!KNOWN_CONFIG_KEYS.has(key)) {
       let suggestion = "";
@@ -145,7 +147,7 @@ function validateConfig(config: RegexPermissionsConfig): void {
           break;
         }
       }
-      process.stderr.write(`[regex-permissions] Unknown config key: "${key}"${suggestion}\n`);
+      process.stderr.write(`[regex-permissions] Unknown config key "${key}" in ${filePath}${suggestion}\n`);
     }
   }
 }
@@ -376,8 +378,6 @@ async function main(): Promise<void> {
   );
 
   const merged = mergeConfigs(projectConfig, globalConfig);
-
-  validateConfig(merged);
 
   if (merged.guardNativePermissions && cwd) {
     const autoAdd = merged.guardNativePermissions === "auto";

--- a/src/test.ts
+++ b/src/test.ts
@@ -453,6 +453,104 @@ function readSettingsAfterRun(tmp: string): Record<string, unknown> {
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
+// --- Tool-name-only rules (no parentheses) ---
+{
+  const tmp = makeTmpWithConfig({
+    regexPermissions: {
+      deny: [
+        { rule: "mcp__github__merge_pull_request", reason: "No merge via MCP" },
+      ],
+      allow: [
+        "mcp__github__list_pulls",
+        "Bash(^git\\s+status)",
+      ],
+    },
+  });
+  test("deny: tool-name-only rule matches MCP tool",
+    { tool_name: "mcp__github__merge_pull_request", tool_input: { owner: "foo", repo: "bar", pull_number: 1 } },
+    "deny", tmp);
+  test("allow: tool-name-only rule matches MCP tool",
+    { tool_name: "mcp__github__list_pulls", tool_input: { owner: "foo", repo: "bar" } },
+    "allow", tmp);
+  test("passthrough: tool-name-only rule does not match other tools",
+    { tool_name: "mcp__github__create_pull", tool_input: { owner: "foo" } },
+    "passthrough", tmp);
+  test("allow: regular parenthesized rule still works alongside tool-name-only",
+    { tool_name: "Bash", tool_input: { command: "git status" } },
+    "allow", tmp);
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- Tool-name-only with regex alternation ---
+{
+  const tmp = makeTmpWithConfig({
+    regexPermissions: {
+      allow: ["Glob|Grep|WebSearch"],
+    },
+  });
+  test("allow: tool-name-only with alternation matches Glob",
+    { tool_name: "Glob", tool_input: { pattern: "**/*.ts" } },
+    "allow", tmp);
+  test("allow: tool-name-only with alternation matches WebSearch",
+    { tool_name: "WebSearch", tool_input: { query: "test" } },
+    "allow", tmp);
+  test("passthrough: tool-name-only with alternation does not match Bash",
+    { tool_name: "Bash", tool_input: { command: "ls" } },
+    "passthrough", tmp);
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- guardNativePermissions: auto mode ---
+{
+  const tmp = makeTmpWithConfig({
+    permissions: {
+      allow: ["Bash(git fetch:*)", "Bash(npm run lint:*)"],
+    },
+    regexPermissions: {
+      guardNativePermissions: "auto",
+      allow: ["Bash(^git\\s+status)"],
+    },
+  });
+
+  const after = readSettingsAfterRun(tmp);
+
+  // Native entries should be removed
+  assert(after.permissions === undefined, "guard-auto: native permissions removed");
+
+  // Regex rules should be auto-added to regexPermissions
+  const rpAllow = (after.regexPermissions as Record<string, unknown>)?.allow as unknown[];
+  assert(
+    rpAllow.some((e: unknown) => typeof e === "object" && (e as Record<string, unknown>)?.rule === "Bash(^git\\s+fetch\\b)"),
+    "guard-auto: Bash(git fetch:*) converted and added to regexPermissions",
+  );
+  assert(
+    rpAllow.some((e: unknown) => typeof e === "object" && (e as Record<string, unknown>)?.rule === "Bash(^npm\\s+run\\s+lint\\b)"),
+    "guard-auto: Bash(npm run lint:*) converted and added to regexPermissions",
+  );
+
+  // Auto-added rules should work immediately (in-memory merge)
+  test("guard-auto: auto-added rule takes effect immediately",
+    { tool_name: "Bash", tool_input: { command: "git fetch origin" } },
+    "allow", tmp);
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- Config validation: unknown key warning ---
+// (We can't easily capture stderr in tests, but we verify it doesn't crash)
+{
+  const tmp = makeTmpWithConfig({
+    regexPermissions: {
+      requierReason: true,
+      allow: ["Bash(^ls)"],
+    },
+  });
+  test("allow: unknown config key does not crash, rules still work",
+    { tool_name: "Bash", tool_input: { command: "ls -la" } },
+    "allow", tmp);
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
 const total = passed + failed;
 console.log(`\n${passed} passed, ${failed} failed (${total} total)\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/src/test.ts
+++ b/src/test.ts
@@ -551,6 +551,51 @@ function readSettingsAfterRun(tmp: string): Record<string, unknown> {
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
+// --- Tool-name-only with requireReason skips string rules ---
+{
+  const tmp = makeTmpWithConfig({
+    regexPermissions: {
+      requireReason: true,
+      allow: [
+        "mcp__github__list_pulls",
+        { rule: "mcp__github__get_me", reason: "Allow get_me" },
+      ],
+    },
+  });
+  test("passthrough: tool-name-only string skipped when requireReason is enabled",
+    { tool_name: "mcp__github__list_pulls", tool_input: { owner: "foo" } },
+    "passthrough", tmp);
+  test("allow: tool-name-only object with reason kept when requireReason is enabled",
+    { tool_name: "mcp__github__get_me", tool_input: {} },
+    "allow", tmp);
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- guardNativePermissions: auto merge precedence ---
+{
+  // "auto" in one config + true in another → "auto" wins
+  const tmp = makeTmpWithConfig({
+    permissions: { allow: ["Bash(git fetch:*)"] },
+    regexPermissions: { guardNativePermissions: "auto", allow: ["Bash(^git\\s+status)"] },
+  });
+  // Write a second config with guardNativePermissions: true
+  fs.writeFileSync(
+    path.join(tmp, ".claude", "settings.json"),
+    JSON.stringify({ regexPermissions: { guardNativePermissions: true } }),
+  );
+
+  const after = readSettingsAfterRun(tmp);
+
+  // "auto" should win — native entry removed AND regex added
+  const rpAllow = (after.regexPermissions as Record<string, unknown>)?.allow as unknown[] || [];
+  assert(
+    rpAllow.some((e: unknown) => typeof e === "object" && (e as Record<string, unknown>)?.rule === "Bash(^git\\s+fetch\\b)"),
+    "guard-auto-merge: auto wins over true, regex rule auto-added",
+  );
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
 const total = passed + failed;
 console.log(`\n${passed} passed, ${failed} failed (${total} total)\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Six improvements in one PR:

1. **Tool-name-only rules** — omit parentheses to match any content, enabling MCP/Skill support:
   ```json
   { "rule": "mcp__github__merge_pull_request", "reason": "No merge via MCP" }
   ```

2. **Guard auto mode** — `"guardNativePermissions": "auto"` converts native entries AND auto-adds them to `regexPermissions.allow`. Rules take effect immediately on the same invocation.

3. **Config validation** — warns on unknown keys with typo suggestions:
   ```
   [regex-permissions] Unknown config key: "requierReason" (did you mean "requireReason"?)
   ```

4. **File cache** — `readJsonFile` with in-memory cache avoids double-reading the same config file per invocation.

5. **Tool-name shorthand** — `"Glob|Grep|WebSearch"` without parentheses matches any content (same as `(.*)`).

6. **Enhanced debug** — shows which rule matched each decision:
   ```
   [regex-permissions] DENY Bash "git push --force" → Bash(^git\s+push.*--force) (No force push)
   [regex-permissions] PASS Bash "unknown-cmd" → no match
   ```

## Test plan

- [x] 68/68 tests pass, including new tests for:
  - Tool-name-only deny/allow for MCP tools
  - Tool-name-only with regex alternation
  - Guard auto mode: entries converted, added to regexPermissions, effective immediately
  - Unknown config key doesn't crash
  - All existing tests still pass (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)