### PR TITLE
fix: use valid relative path in marketplace source field

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "regex-permissions",
-      "source": "."
+      "source": "./"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix `source: "."` → `source: "./"` in marketplace.json to satisfy the schema validator requiring paths starting with `./`

## Test plan
- [x] All 71 tests pass
- [ ] Verify `/plugin marketplace add amehmeto/regex-permissions` works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)