### PR TITLE
fix: improve suggestion heuristics lost in #11 squash merge

### DIFF
--- a/dist/check-permissions.js
+++ b/dist/check-permissions.js
@@ -170,8 +170,7 @@ function matchesAnyLine(rule, toolName, content, lines) {
         return false;
     return lines.some((line) => ruleMatches(rule, toolName, line));
 }
-function evaluate(rules, toolName, toolInput) {
-    const content = getPrimaryContent(toolName, toolInput);
+function evaluate(rules, toolName, content) {
     const contentPreview = content ? JSON.stringify(content.length > 80 ? content.slice(0, 80) + "…" : content) : "(no content)";
     const lines = content?.includes("\n")
         ? content.split("\n").map((l) => l.trim()).filter(Boolean)
@@ -198,6 +197,7 @@ function evaluate(rules, toolName, toolInput) {
     return null;
 }
 // --- Regex suggestion ---
+const BASH_WRAPPERS = /^(env|nohup|time|nice|ionice|timeout|sudo)$/;
 function escapeRegex(s) {
     return s.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -209,10 +209,18 @@ function generateRegexSuggestion(toolName, content) {
         const tokens = firstLine.split(/\s+/).filter(Boolean);
         if (tokens.length === 0)
             return `Bash(.*)`;
-        if (tokens.length >= 2 && /^[a-zA-Z]/.test(tokens[1])) {
-            return `Bash(^${escapeRegex(tokens[0])}\\s+${escapeRegex(tokens[1])}\\b)`;
+        // Skip wrapper commands (env, nohup, time, sudo, etc.) and env var assignments (FOO=bar)
+        let cmdIdx = 0;
+        while (cmdIdx < tokens.length - 1 && (BASH_WRAPPERS.test(tokens[cmdIdx]) || /^\w+=/.test(tokens[cmdIdx]))) {
+            cmdIdx++;
         }
-        return `Bash(^${escapeRegex(tokens[0])}\\b)`;
+        const cmd = tokens[cmdIdx];
+        const subcmd = tokens[cmdIdx + 1];
+        // Include subcommand if it looks like one (starts with letter, not a path, not a filename, not an assignment)
+        if (subcmd && /^[a-zA-Z]/.test(subcmd) && !/[/.=]/.test(subcmd)) {
+            return `Bash(^${escapeRegex(cmd)}\\s+${escapeRegex(subcmd)}\\b)`;
+        }
+        return `Bash(^${escapeRegex(cmd)}\\b)`;
     }
     if (toolName === "Edit" || toolName === "Write" || toolName === "Read") {
         const extMatch = content.match(/\.(\w+)$/);
@@ -351,10 +359,10 @@ async function main() {
     if (!rules.deny.length && !rules.ask.length && !rules.allow.length && !merged.suggestOnPassthrough)
         return;
     debug(`Loaded ${rules.deny.length} deny, ${rules.ask.length} ask, ${rules.allow.length} allow rules`);
-    const result = evaluate(rules, tool_name, tool_input);
+    const content = getPrimaryContent(tool_name, tool_input);
+    const result = evaluate(rules, tool_name, content);
     if (!result) {
         if (merged.suggestOnPassthrough) {
-            const content = getPrimaryContent(tool_name, tool_input);
             const suggestion = generateRegexSuggestion(tool_name, content);
             debug(`SUGGEST ${tool_name} → ${suggestion}`);
             const output = {

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -221,9 +221,8 @@ function matchesAnyLine(
 function evaluate(
   rules: PreparedRules,
   toolName: string,
-  toolInput: Record<string, unknown>,
+  content: string | undefined,
 ): { decision: "deny" | "ask" | "allow"; reason?: string } | null {
-  const content = getPrimaryContent(toolName, toolInput);
   const contentPreview = content ? JSON.stringify(content.length > 80 ? content.slice(0, 80) + "…" : content) : "(no content)";
   const lines = content?.includes("\n")
     ? content.split("\n").map((l) => l.trim()).filter(Boolean)
@@ -256,6 +255,8 @@ function evaluate(
 
 // --- Regex suggestion ---
 
+const BASH_WRAPPERS = /^(env|nohup|time|nice|ionice|timeout|sudo)$/;
+
 function escapeRegex(s: string): string {
   return s.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -268,10 +269,20 @@ function generateRegexSuggestion(toolName: string, content: string | undefined):
     const tokens = firstLine.split(/\s+/).filter(Boolean);
     if (tokens.length === 0) return `Bash(.*)`;
 
-    if (tokens.length >= 2 && /^[a-zA-Z]/.test(tokens[1])) {
-      return `Bash(^${escapeRegex(tokens[0])}\\s+${escapeRegex(tokens[1])}\\b)`;
+    // Skip wrapper commands (env, nohup, time, sudo, etc.) and env var assignments (FOO=bar)
+    let cmdIdx = 0;
+    while (cmdIdx < tokens.length - 1 && (BASH_WRAPPERS.test(tokens[cmdIdx]) || /^\w+=/.test(tokens[cmdIdx]))) {
+      cmdIdx++;
     }
-    return `Bash(^${escapeRegex(tokens[0])}\\b)`;
+
+    const cmd = tokens[cmdIdx];
+    const subcmd = tokens[cmdIdx + 1];
+
+    // Include subcommand if it looks like one (starts with letter, not a path, not a filename, not an assignment)
+    if (subcmd && /^[a-zA-Z]/.test(subcmd) && !/[/.=]/.test(subcmd)) {
+      return `Bash(^${escapeRegex(cmd)}\\s+${escapeRegex(subcmd)}\\b)`;
+    }
+    return `Bash(^${escapeRegex(cmd)}\\b)`;
   }
 
   if (toolName === "Edit" || toolName === "Write" || toolName === "Read") {
@@ -442,11 +453,11 @@ async function main(): Promise<void> {
 
   debug(`Loaded ${rules.deny.length} deny, ${rules.ask.length} ask, ${rules.allow.length} allow rules`);
 
-  const result = evaluate(rules, tool_name, tool_input);
+  const content = getPrimaryContent(tool_name, tool_input);
+  const result = evaluate(rules, tool_name, content);
 
   if (!result) {
     if (merged.suggestOnPassthrough) {
-      const content = getPrimaryContent(tool_name, tool_input);
       const suggestion = generateRegexSuggestion(tool_name, content);
       debug(`SUGGEST ${tool_name} → ${suggestion}`);
       const output: HookOutput = {

--- a/src/test.ts
+++ b/src/test.ts
@@ -681,7 +681,7 @@ function readSettingsAfterRun(tmp: string): Record<string, unknown> {
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
-// --- suggestOnPassthrough: command with flags (second token starts with -) ---
+// --- suggestOnPassthrough: bash heuristics ---
 {
   const tmp = makeTmpWithConfig({
     regexPermissions: {
@@ -689,11 +689,52 @@ function readSettingsAfterRun(tmp: string): Record<string, unknown> {
       allow: [],
     },
   });
+
+  // Flags are skipped — only first token used
   {
     const result = run({ tool_name: "Bash", tool_input: { command: "ls -la /tmp" }, cwd: tmp });
     const r = reason(result);
     assert(r.includes("Bash(^ls\\\\b)"), "suggest: command with flags suggests first token only");
   }
+
+  // Path-like second token is skipped
+  {
+    const result = run({ tool_name: "Bash", tool_input: { command: "cat /etc/hosts" }, cwd: tmp });
+    const r = reason(result);
+    assert(r.includes("Bash(^cat\\\\b)"), "suggest: path argument skipped, only command suggested");
+  }
+
+  // Wrapper commands (env, nohup, time) are skipped
+  {
+    const result = run({ tool_name: "Bash", tool_input: { command: "env FOO=bar node server.js" }, cwd: tmp });
+    const r = reason(result);
+    assert(r.includes("Bash(^node\\\\b)"), "suggest: env + var assignment skipped, actual command suggested");
+  }
+  {
+    const result = run({ tool_name: "Bash", tool_input: { command: "time git status" }, cwd: tmp });
+    const r = reason(result);
+    assert(r.includes("Bash(^git\\\\s+status\\\\b)"), "suggest: wrapper 'time' skipped, git status suggested");
+  }
+  {
+    const result = run({ tool_name: "Bash", tool_input: { command: "nohup python3 app.py" }, cwd: tmp });
+    const r = reason(result);
+    assert(r.includes("Bash(^python3\\\\b)"), "suggest: wrapper 'nohup' skipped, python3 suggested");
+  }
+
+  // Bare env var assignment without wrapper
+  {
+    const result = run({ tool_name: "Bash", tool_input: { command: "FOO=bar npm test" }, cwd: tmp });
+    const r = reason(result);
+    assert(r.includes("Bash(^npm\\\\s+test\\\\b)"), "suggest: env var assignment skipped, npm test suggested");
+  }
+
+  // sudo is treated as a wrapper — suggests the actual command
+  {
+    const result = run({ tool_name: "Bash", tool_input: { command: "sudo systemctl restart nginx" }, cwd: tmp });
+    const r = reason(result);
+    assert(r.includes("Bash(^systemctl\\\\s+restart\\\\b)"), "suggest: wrapper 'sudo' skipped, actual command suggested");
+  }
+
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
## Summary
Fixes from PR #11 commits 2 and 3 that were lost during squash merge:
- Refactor `evaluate()` to accept `content` directly (avoids double `getPrimaryContent` call)
- Skip wrapper commands (`env`, `nohup`, `time`, `sudo`, `nice`, `ionice`, `timeout`) and env var assignments (`FOO=bar`) when generating Bash suggestions
- Skip path-like (`/etc/hosts`) and filename-like (`app.py`) tokens as subcommands
- Hoist `BASH_WRAPPERS` regex to module scope to avoid recompilation per call

## Test plan
- [x] 91 tests pass (6 new for heuristic edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)