### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "regex-permissions",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Regex-based permission rules for Claude Code — collapse hundreds of literal allow/deny/ask rules into compact patterns",
   "author": {
     "name": "amehmeto"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regex-permissions",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "description": "Regex-based permission rules for Claude Code",
   "author": "amehmeto",


### PR DESCRIPTION
## Summary
- Bump version from 0.9.0 to 0.10.0 in `package.json` and `.claude-plugin/plugin.json`
- Triggers plugin cache invalidation in projects using regex-permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)