### PR TITLE
feat(guard): PostToolUse hook for immediate rule conversion

### DIFF
--- a/dist/check-permissions.js
+++ b/dist/check-permissions.js
@@ -318,16 +318,77 @@ function guardNativePermissions(filePath, autoAdd) {
     fs_1.default.writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n");
     for (const { entry, suggestion } of removed) {
         if (autoAdd) {
-            process.stderr.write(`[regex-permissions] Converted native allow: ${entry} → { "rule": ${JSON.stringify(suggestion)} }\n`);
+            debug(`Converted native allow: ${entry} → { "rule": ${JSON.stringify(suggestion)} }`);
         }
         else {
-            process.stderr.write(`[regex-permissions] Removed native allow: ${entry}\n` +
-                `  → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }\n`);
+            debug(`Removed native allow: ${entry} → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }`);
         }
     }
     return addedRules;
 }
+// Convert a single just-approved native rule matching this tool use
+function guardApprovedRule(filePath, toolName, content) {
+    // Re-read from disk (Claude Code may have just written to it)
+    let json;
+    try {
+        json = JSON.parse(fs_1.default.readFileSync(filePath, "utf8"));
+    }
+    catch {
+        return;
+    }
+    const perms = json.permissions;
+    if (!perms)
+        return;
+    const allowEntries = perms.allow;
+    if (!Array.isArray(allowEntries))
+        return;
+    // Find the native entry that matches this tool use
+    let matchIdx = -1;
+    let matchRule = "";
+    for (let i = 0; i < allowEntries.length; i++) {
+        const entry = allowEntries[i];
+        const rule = typeof entry === "string" ? entry : entry?.rule;
+        if (typeof rule !== "string")
+            continue;
+        // Must be a managed tool pattern: Tool(...)
+        if (!MANAGED_TOOL_RE.test(rule))
+            continue;
+        const m = rule.match(/^(\w+)\((.+)\)$/);
+        if (!m)
+            continue;
+        const [, entryTool, entryPattern] = m;
+        if (entryTool !== toolName)
+            continue;
+        // Check if this native rule matches the current content
+        // Native rules are either exact or prefix (:*)
+        const prefix = entryPattern.replace(/:\*$/, "");
+        if (content && (content === prefix || content.startsWith(prefix + " ") || content.startsWith(prefix))) {
+            matchIdx = i;
+            matchRule = rule;
+            break;
+        }
+    }
+    if (matchIdx === -1)
+        return;
+    const suggestion = suggestRegex(matchRule);
+    // Remove from permissions.allow
+    allowEntries.splice(matchIdx, 1);
+    if (allowEntries.length === 0)
+        delete perms.allow;
+    if (Object.keys(perms).length === 0)
+        delete json.permissions;
+    // Add to regexPermissions.allow
+    if (!json.regexPermissions)
+        json.regexPermissions = {};
+    const rp = json.regexPermissions;
+    if (!rp.allow)
+        rp.allow = [];
+    rp.allow.push({ rule: suggestion, reason: "Auto-converted from native permissions" });
+    fs_1.default.writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n");
+    debug(`PostToolUse: converted ${matchRule} → ${suggestion}`);
+}
 // --- Main ---
+const mode = process.argv[2] || "pre";
 async function main() {
     let input;
     try {
@@ -340,14 +401,28 @@ async function main() {
         return;
     }
     const { tool_name, tool_input, cwd } = input;
-    if (!tool_name)
+    if (!tool_name || !cwd)
         return;
-    const projectConfig = cwd
-        ? mergeConfigs(loadConfig(path_1.default.join(cwd, ".claude", "settings.json")), loadConfig(path_1.default.join(cwd, ".claude", "settings.local.json")))
-        : null;
+    if (mode === "post") {
+        return handlePostToolUse(tool_name, tool_input, cwd);
+    }
+    return handlePreToolUse(tool_name, tool_input, cwd);
+}
+function handlePostToolUse(toolName, toolInput, cwd) {
+    // Load config to check if guardNativePermissions is enabled
+    const settingsPath = path_1.default.join(cwd, ".claude", "settings.local.json");
+    const config = loadConfig(settingsPath);
+    if (!config?.guardNativePermissions)
+        return;
+    const content = getPrimaryContent(toolName, toolInput);
+    guardApprovedRule(settingsPath, toolName, content);
+}
+function handlePreToolUse(toolName, toolInput, cwd) {
+    const projectConfig = mergeConfigs(loadConfig(path_1.default.join(cwd, ".claude", "settings.json")), loadConfig(path_1.default.join(cwd, ".claude", "settings.local.json")));
     const globalHome = path_1.default.join(os_1.default.homedir(), ".claude");
     const globalConfig = mergeConfigs(loadConfig(path_1.default.join(globalHome, "settings.json")), loadConfig(path_1.default.join(globalHome, "settings.local.json")));
     const merged = mergeConfigs(projectConfig, globalConfig);
+    // Bulk guard: clean up any leftover native entries (PreToolUse)
     if (merged.guardNativePermissions && cwd) {
         const autoAdd = merged.guardNativePermissions === "auto";
         const added = guardNativePermissions(path_1.default.join(cwd, ".claude", "settings.local.json"), autoAdd);
@@ -359,12 +434,12 @@ async function main() {
     if (!rules.deny.length && !rules.ask.length && !rules.allow.length && !merged.suggestOnPassthrough)
         return;
     debug(`Loaded ${rules.deny.length} deny, ${rules.ask.length} ask, ${rules.allow.length} allow rules`);
-    const content = getPrimaryContent(tool_name, tool_input);
-    const result = evaluate(rules, tool_name, content);
+    const content = getPrimaryContent(toolName, toolInput);
+    const result = evaluate(rules, toolName, content);
     if (!result) {
         if (merged.suggestOnPassthrough) {
-            const suggestion = generateRegexSuggestion(tool_name, content);
-            debug(`SUGGEST ${tool_name} → ${suggestion}`);
+            const suggestion = generateRegexSuggestion(toolName, content);
+            debug(`SUGGEST ${toolName} → ${suggestion}`);
             const output = {
                 hookSpecificOutput: {
                     hookEventName: "PreToolUse",

--- a/dist/check-permissions.js
+++ b/dist/check-permissions.js
@@ -243,7 +243,7 @@ function generateRegexSuggestion(toolName, content) {
     return toolName;
 }
 // --- Native permissions guard ---
-const MANAGED_TOOL_RE = /^(Bash|Edit|Write|Read|WebFetch|Grep|Glob|WebSearch)\(.+\)$/;
+const MANAGED_TOOL_RE = /^(Bash|Edit|Write|Read|WebFetch|Grep|Glob|WebSearch)\((.+)\)$/;
 function suggestRegex(native) {
     const m = native.match(/^([\w|]+)\((.+)\)$/);
     if (!m)
@@ -351,9 +351,7 @@ function guardApprovedRule(filePath, toolName, content) {
         if (typeof rule !== "string")
             continue;
         // Must be a managed tool pattern: Tool(...)
-        if (!MANAGED_TOOL_RE.test(rule))
-            continue;
-        const m = rule.match(/^(\w+)\((.+)\)$/);
+        const m = rule.match(MANAGED_TOOL_RE);
         if (!m)
             continue;
         const [, entryTool, entryPattern] = m;
@@ -362,7 +360,7 @@ function guardApprovedRule(filePath, toolName, content) {
         // Check if this native rule matches the current content
         // Native rules are either exact or prefix (:*)
         const prefix = entryPattern.replace(/:\*$/, "");
-        if (content && (content === prefix || content.startsWith(prefix + " ") || content.startsWith(prefix))) {
+        if (content && (content === prefix || content.startsWith(prefix + " "))) {
             matchIdx = i;
             matchRule = rule;
             break;
@@ -401,24 +399,32 @@ async function main() {
         return;
     }
     const { tool_name, tool_input, cwd } = input;
-    if (!tool_name || !cwd)
+    if (!tool_name)
         return;
     if (mode === "post") {
+        if (!cwd)
+            return;
         return handlePostToolUse(tool_name, tool_input, cwd);
     }
     return handlePreToolUse(tool_name, tool_input, cwd);
 }
 function handlePostToolUse(toolName, toolInput, cwd) {
-    // Load config to check if guardNativePermissions is enabled
-    const settingsPath = path_1.default.join(cwd, ".claude", "settings.local.json");
-    const config = loadConfig(settingsPath);
-    if (!config?.guardNativePermissions)
+    // Check merged config for guardNativePermissions (same sources as PreToolUse)
+    const projectConfig = mergeConfigs(loadConfig(path_1.default.join(cwd, ".claude", "settings.json")), loadConfig(path_1.default.join(cwd, ".claude", "settings.local.json")));
+    const globalHome = path_1.default.join(os_1.default.homedir(), ".claude");
+    const globalConfig = mergeConfigs(loadConfig(path_1.default.join(globalHome, "settings.json")), loadConfig(path_1.default.join(globalHome, "settings.local.json")));
+    const merged = mergeConfigs(projectConfig, globalConfig);
+    if (!merged.guardNativePermissions)
         return;
+    // Always write to project settings.local.json
+    const settingsPath = path_1.default.join(cwd, ".claude", "settings.local.json");
     const content = getPrimaryContent(toolName, toolInput);
     guardApprovedRule(settingsPath, toolName, content);
 }
 function handlePreToolUse(toolName, toolInput, cwd) {
-    const projectConfig = mergeConfigs(loadConfig(path_1.default.join(cwd, ".claude", "settings.json")), loadConfig(path_1.default.join(cwd, ".claude", "settings.local.json")));
+    const projectConfig = cwd
+        ? mergeConfigs(loadConfig(path_1.default.join(cwd, ".claude", "settings.json")), loadConfig(path_1.default.join(cwd, ".claude", "settings.local.json")))
+        : null;
     const globalHome = path_1.default.join(os_1.default.homedir(), ".claude");
     const globalConfig = mergeConfigs(loadConfig(path_1.default.join(globalHome, "settings.json")), loadConfig(path_1.default.join(globalHome, "settings.local.json")));
     const merged = mergeConfigs(projectConfig, globalConfig);

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js\" pre",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/check-permissions.js\" post",
             "timeout": 5
           }
         ]

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -392,21 +392,80 @@ function guardNativePermissions(filePath: string, autoAdd: boolean): RuleEntry[]
 
   for (const { entry, suggestion } of removed) {
     if (autoAdd) {
-      process.stderr.write(
-        `[regex-permissions] Converted native allow: ${entry} → { "rule": ${JSON.stringify(suggestion)} }\n`,
-      );
+      debug(`Converted native allow: ${entry} → { "rule": ${JSON.stringify(suggestion)} }`);
     } else {
-      process.stderr.write(
-        `[regex-permissions] Removed native allow: ${entry}\n` +
-        `  → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }\n`,
-      );
+      debug(`Removed native allow: ${entry} → Add to regexPermissions.allow: { "rule": ${JSON.stringify(suggestion)}, "reason": "..." }`);
     }
   }
 
   return addedRules;
 }
 
+// Convert a single just-approved native rule matching this tool use
+function guardApprovedRule(filePath: string, toolName: string, content: string | undefined): void {
+  // Re-read from disk (Claude Code may have just written to it)
+  let json: Record<string, unknown>;
+  try {
+    json = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return;
+  }
+
+  const perms = json.permissions as Record<string, unknown> | undefined;
+  if (!perms) return;
+
+  const allowEntries = perms.allow;
+  if (!Array.isArray(allowEntries)) return;
+
+  // Find the native entry that matches this tool use
+  let matchIdx = -1;
+  let matchRule = "";
+  for (let i = 0; i < allowEntries.length; i++) {
+    const entry = allowEntries[i];
+    const rule = typeof entry === "string" ? entry : (entry as Record<string, unknown>)?.rule;
+    if (typeof rule !== "string") continue;
+
+    // Must be a managed tool pattern: Tool(...)
+    if (!MANAGED_TOOL_RE.test(rule)) continue;
+
+    const m = rule.match(/^(\w+)\((.+)\)$/);
+    if (!m) continue;
+    const [, entryTool, entryPattern] = m;
+
+    if (entryTool !== toolName) continue;
+
+    // Check if this native rule matches the current content
+    // Native rules are either exact or prefix (:*)
+    const prefix = entryPattern.replace(/:\*$/, "");
+    if (content && (content === prefix || content.startsWith(prefix + " ") || content.startsWith(prefix))) {
+      matchIdx = i;
+      matchRule = rule;
+      break;
+    }
+  }
+
+  if (matchIdx === -1) return;
+
+  const suggestion = suggestRegex(matchRule);
+
+  // Remove from permissions.allow
+  allowEntries.splice(matchIdx, 1);
+  if (allowEntries.length === 0) delete perms.allow;
+  if (Object.keys(perms).length === 0) delete json.permissions;
+
+  // Add to regexPermissions.allow
+  if (!json.regexPermissions) json.regexPermissions = {};
+  const rp = json.regexPermissions as RegexPermissionsConfig;
+  if (!rp.allow) rp.allow = [];
+  (rp.allow as RuleEntry[]).push({ rule: suggestion, reason: "Auto-converted from native permissions" });
+
+  fs.writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n");
+  debug(`PostToolUse: converted ${matchRule} → ${suggestion}`);
+}
+
 // --- Main ---
+
+const mode = process.argv[2] || "pre";
 
 async function main(): Promise<void> {
   let input: HookInput;
@@ -419,14 +478,30 @@ async function main(): Promise<void> {
   }
 
   const { tool_name, tool_input, cwd } = input;
-  if (!tool_name) return;
+  if (!tool_name || !cwd) return;
 
-  const projectConfig = cwd
-    ? mergeConfigs(
-        loadConfig(path.join(cwd, ".claude", "settings.json")),
-        loadConfig(path.join(cwd, ".claude", "settings.local.json")),
-      )
-    : null;
+  if (mode === "post") {
+    return handlePostToolUse(tool_name, tool_input, cwd);
+  }
+
+  return handlePreToolUse(tool_name, tool_input, cwd);
+}
+
+function handlePostToolUse(toolName: string, toolInput: Record<string, unknown>, cwd: string): void {
+  // Load config to check if guardNativePermissions is enabled
+  const settingsPath = path.join(cwd, ".claude", "settings.local.json");
+  const config = loadConfig(settingsPath);
+  if (!config?.guardNativePermissions) return;
+
+  const content = getPrimaryContent(toolName, toolInput);
+  guardApprovedRule(settingsPath, toolName, content);
+}
+
+function handlePreToolUse(toolName: string, toolInput: Record<string, unknown>, cwd: string): void {
+  const projectConfig = mergeConfigs(
+    loadConfig(path.join(cwd, ".claude", "settings.json")),
+    loadConfig(path.join(cwd, ".claude", "settings.local.json")),
+  );
 
   const globalHome = path.join(os.homedir(), ".claude");
   const globalConfig = mergeConfigs(
@@ -436,6 +511,7 @@ async function main(): Promise<void> {
 
   const merged = mergeConfigs(projectConfig, globalConfig);
 
+  // Bulk guard: clean up any leftover native entries (PreToolUse)
   if (merged.guardNativePermissions && cwd) {
     const autoAdd = merged.guardNativePermissions === "auto";
     const added = guardNativePermissions(
@@ -453,13 +529,13 @@ async function main(): Promise<void> {
 
   debug(`Loaded ${rules.deny.length} deny, ${rules.ask.length} ask, ${rules.allow.length} allow rules`);
 
-  const content = getPrimaryContent(tool_name, tool_input);
-  const result = evaluate(rules, tool_name, content);
+  const content = getPrimaryContent(toolName, toolInput);
+  const result = evaluate(rules, toolName, content);
 
   if (!result) {
     if (merged.suggestOnPassthrough) {
-      const suggestion = generateRegexSuggestion(tool_name, content);
-      debug(`SUGGEST ${tool_name} → ${suggestion}`);
+      const suggestion = generateRegexSuggestion(toolName, content);
+      debug(`SUGGEST ${toolName} → ${suggestion}`);
       const output: HookOutput = {
         hookSpecificOutput: {
           hookEventName: "PreToolUse",

--- a/src/check-permissions.ts
+++ b/src/check-permissions.ts
@@ -311,7 +311,7 @@ function generateRegexSuggestion(toolName: string, content: string | undefined):
 
 // --- Native permissions guard ---
 
-const MANAGED_TOOL_RE = /^(Bash|Edit|Write|Read|WebFetch|Grep|Glob|WebSearch)\(.+\)$/;
+const MANAGED_TOOL_RE = /^(Bash|Edit|Write|Read|WebFetch|Grep|Glob|WebSearch)\((.+)\)$/;
 
 function suggestRegex(native: string): string {
   const m = native.match(/^([\w|]+)\((.+)\)$/);
@@ -426,9 +426,7 @@ function guardApprovedRule(filePath: string, toolName: string, content: string |
     if (typeof rule !== "string") continue;
 
     // Must be a managed tool pattern: Tool(...)
-    if (!MANAGED_TOOL_RE.test(rule)) continue;
-
-    const m = rule.match(/^(\w+)\((.+)\)$/);
+    const m = rule.match(MANAGED_TOOL_RE);
     if (!m) continue;
     const [, entryTool, entryPattern] = m;
 
@@ -437,7 +435,7 @@ function guardApprovedRule(filePath: string, toolName: string, content: string |
     // Check if this native rule matches the current content
     // Native rules are either exact or prefix (:*)
     const prefix = entryPattern.replace(/:\*$/, "");
-    if (content && (content === prefix || content.startsWith(prefix + " ") || content.startsWith(prefix))) {
+    if (content && (content === prefix || content.startsWith(prefix + " "))) {
       matchIdx = i;
       matchRule = rule;
       break;
@@ -478,9 +476,10 @@ async function main(): Promise<void> {
   }
 
   const { tool_name, tool_input, cwd } = input;
-  if (!tool_name || !cwd) return;
+  if (!tool_name) return;
 
   if (mode === "post") {
+    if (!cwd) return;
     return handlePostToolUse(tool_name, tool_input, cwd);
   }
 
@@ -488,20 +487,32 @@ async function main(): Promise<void> {
 }
 
 function handlePostToolUse(toolName: string, toolInput: Record<string, unknown>, cwd: string): void {
-  // Load config to check if guardNativePermissions is enabled
-  const settingsPath = path.join(cwd, ".claude", "settings.local.json");
-  const config = loadConfig(settingsPath);
-  if (!config?.guardNativePermissions) return;
-
-  const content = getPrimaryContent(toolName, toolInput);
-  guardApprovedRule(settingsPath, toolName, content);
-}
-
-function handlePreToolUse(toolName: string, toolInput: Record<string, unknown>, cwd: string): void {
+  // Check merged config for guardNativePermissions (same sources as PreToolUse)
   const projectConfig = mergeConfigs(
     loadConfig(path.join(cwd, ".claude", "settings.json")),
     loadConfig(path.join(cwd, ".claude", "settings.local.json")),
   );
+  const globalHome = path.join(os.homedir(), ".claude");
+  const globalConfig = mergeConfigs(
+    loadConfig(path.join(globalHome, "settings.json")),
+    loadConfig(path.join(globalHome, "settings.local.json")),
+  );
+  const merged = mergeConfigs(projectConfig, globalConfig);
+  if (!merged.guardNativePermissions) return;
+
+  // Always write to project settings.local.json
+  const settingsPath = path.join(cwd, ".claude", "settings.local.json");
+  const content = getPrimaryContent(toolName, toolInput);
+  guardApprovedRule(settingsPath, toolName, content);
+}
+
+function handlePreToolUse(toolName: string, toolInput: Record<string, unknown>, cwd: string | undefined): void {
+  const projectConfig = cwd
+    ? mergeConfigs(
+        loadConfig(path.join(cwd, ".claude", "settings.json")),
+        loadConfig(path.join(cwd, ".claude", "settings.local.json")),
+      )
+    : null;
 
   const globalHome = path.join(os.homedir(), ".claude");
   const globalConfig = mergeConfigs(

--- a/src/test.ts
+++ b/src/test.ts
@@ -16,8 +16,8 @@ function makeTmpWithConfig(config: object): string {
   return tmp;
 }
 
-function run(input: HookInput): HookOutput {
-  const result = execFileSync("node", [SCRIPT], {
+function run(input: HookInput, mode: string = "pre"): HookOutput {
+  const result = execFileSync("node", [SCRIPT, mode], {
     input: JSON.stringify(input),
     encoding: "utf8",
     timeout: 5000,
@@ -734,6 +734,94 @@ function readSettingsAfterRun(tmp: string): Record<string, unknown> {
     const r = reason(result);
     assert(r.includes("Bash(^systemctl\\\\s+restart\\\\b)"), "suggest: wrapper 'sudo' skipped, actual command suggested");
   }
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- PostToolUse: guardApprovedRule ---
+{
+  const tmp = makeTmpWithConfig({
+    permissions: {
+      allow: ["Edit", "Read"],
+    },
+    regexPermissions: {
+      guardNativePermissions: "auto",
+      allow: ["Bash(^git\\s+status)"],
+    },
+  });
+  const settingsPath = path.join(tmp, ".claude", "settings.local.json");
+
+  // Simulate Claude Code adding a native rule after user approval
+  const data = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+  data.permissions.allow.push("Bash(cowsay:*)");
+  fs.writeFileSync(settingsPath, JSON.stringify(data));
+
+  // Run PostToolUse — should convert the just-approved rule
+  run({ tool_name: "Bash", tool_input: { command: "cowsay hello" }, cwd: tmp }, "post");
+
+  const after = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+  const nativeAllow = (after.permissions?.allow || []) as string[];
+  const regexAllow = (after.regexPermissions?.allow || []) as (string | { rule: string })[];
+
+  assert(!nativeAllow.includes("Bash(cowsay:*)"), "post: native Bash(cowsay:*) removed");
+  assert(nativeAllow.includes("Edit"), "post: bare Edit kept");
+  assert(nativeAllow.includes("Read"), "post: bare Read kept");
+  assert(
+    regexAllow.some((r) => typeof r === "object" && r.rule === "Bash(^cowsay\\b)"),
+    "post: regex Bash(^cowsay\\b) added to regexPermissions",
+  );
+
+  // Run PostToolUse again for unrelated tool — should not change anything
+  const before2 = fs.readFileSync(settingsPath, "utf8");
+  run({ tool_name: "Bash", tool_input: { command: "git status" }, cwd: tmp }, "post");
+  const after2 = fs.readFileSync(settingsPath, "utf8");
+  assert(before2 === after2, "post: unrelated tool use does not modify file");
+
+  // PostToolUse with no native rule to convert — no-op
+  run({ tool_name: "Bash", tool_input: { command: "unknown-cmd" }, cwd: tmp }, "post");
+  const after3 = fs.readFileSync(settingsPath, "utf8");
+  assert(before2 === after3, "post: no matching native rule is a no-op");
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- PostToolUse: prefix match must be exact (no substring) ---
+{
+  const tmp = makeTmpWithConfig({
+    permissions: {
+      allow: ["Bash(cow:*)"],
+    },
+    regexPermissions: {
+      guardNativePermissions: "auto",
+    },
+  });
+  const settingsPath = path.join(tmp, ".claude", "settings.local.json");
+
+  // "cowsay hello" should NOT match "cow:*" because "cowsay" != "cow" and doesn't start with "cow "
+  run({ tool_name: "Bash", tool_input: { command: "cowsay hello" }, cwd: tmp }, "post");
+  const after = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+  const nativeAllow = (after.permissions?.allow || []) as string[];
+  assert(nativeAllow.includes("Bash(cow:*)"), "post: Bash(cow:*) NOT removed for cowsay (no substring match)");
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- PostToolUse: disabled when guardNativePermissions is not set ---
+{
+  const tmp = makeTmpWithConfig({
+    permissions: {
+      allow: ["Bash(cowsay:*)"],
+    },
+    regexPermissions: {
+      allow: ["Bash(^git\\s+status)"],
+    },
+  });
+  const settingsPath = path.join(tmp, ".claude", "settings.local.json");
+
+  run({ tool_name: "Bash", tool_input: { command: "cowsay hello" }, cwd: tmp }, "post");
+  const after = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+  const nativeAllow = (after.permissions?.allow || []) as string[];
+  assert(nativeAllow.includes("Bash(cowsay:*)"), "post: native rule kept when guardNativePermissions is not set");
 
   fs.rmSync(tmp, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

- Add PostToolUse hook that immediately converts a just-approved native rule to regex in `regexPermissions.allow`
- Previously, approved rules were only converted on the NEXT tool use (two-step). Now it's one step.
- Move guard stderr output to debug-only to prevent hook errors in Claude Code

## How it works

1. **PreToolUse**: `suggestOnPassthrough` returns `ask` with a regex suggestion
2. User approves → Claude Code adds native rule (e.g. `Bash(cowsay:*)`) to `permissions.allow`
3. **PostToolUse**: detects the native rule matching this tool use, removes it, converts to regex (`Bash(^cowsay\b)`), and adds it to `regexPermissions.allow`

## Test plan

- [x] 91 existing tests pass
- [x] End-to-end simulation: PreToolUse suggest → native rule added → PostToolUse converts → `regexPermissions.allow` updated, `permissions.allow` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)